### PR TITLE
WiFi接続のタイムアウト処理を実装

### DIFF
--- a/M5LLMServer.ino
+++ b/M5LLMServer.ino
@@ -107,12 +107,30 @@ void setup() {
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
 
+  unsigned long startAttemptTime = millis();
+  bool connectionSuccess = false;
+
   while (WiFi.status() != WL_CONNECTED) {
+    if (millis() - startAttemptTime > CONNECTION_TIMEOUT) {
+      M5.Display.println("\nWiFi connection timeout!");
+      break;
+    }
     delay(500);
     M5.Display.print(".");
   }
 
-  M5.Display.printf("\nConnected!\nIP: %s\n", WiFi.localIP().toString().c_str());
+  if (WiFi.status() == WL_CONNECTED) {
+    connectionSuccess = true;
+    M5.Display.printf("\nConnected!\nIP: %s\n", WiFi.localIP().toString().c_str());
+  } else {
+    M5.Display.println("\nFailed to connect to WiFi!");
+    M5.Display.println("Please check your WiFi credentials");
+    M5.Display.println("or network availability.");
+    // WiFiをオフにして電力消費を抑える
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+    return; // セットアップを中止
+  }
 
   if (MDNS.begin("m5llm")) {
     M5.Display.println("MDNS responder started");

--- a/example/HelloServer/HelloServer.ino
+++ b/example/HelloServer/HelloServer.ino
@@ -7,6 +7,7 @@
 WebServer server(80);
 
 const int led = 13;
+const unsigned long CONNECTION_TIMEOUT = 30000;  // 30 seconds timeout
 
 void handleRoot() {
   digitalWrite(led, 1);
@@ -39,16 +40,35 @@ void setup(void) {
   WiFi.begin(ssid, password);
   Serial.println("");
 
-  // Wait for connection
+  // Wait for connection with timeout
+  unsigned long startAttemptTime = millis();
+  bool connectionSuccess = false;
+
+  Serial.print("Connecting to WiFi");
   while (WiFi.status() != WL_CONNECTED) {
+    if (millis() - startAttemptTime > CONNECTION_TIMEOUT) {
+      Serial.println("\nWiFi connection timeout!");
+      break;
+    }
     delay(500);
     Serial.print(".");
   }
-  Serial.println("");
-  Serial.print("Connected to ");
-  Serial.println(ssid);
-  Serial.print("IP address: ");
-  Serial.println(WiFi.localIP());
+  Serial.println();
+
+  if (WiFi.status() == WL_CONNECTED) {
+    connectionSuccess = true;
+    Serial.print("Connected to ");
+    Serial.println(ssid);
+    Serial.print("IP address: ");
+    Serial.println(WiFi.localIP());
+  } else {
+    Serial.println("Failed to connect to WiFi!");
+    Serial.println("Please check your WiFi credentials or network availability.");
+    // WiFiをオフにして電力消費を抑える
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_OFF);
+    return; // セットアップを中止
+  }
 
   if (MDNS.begin("esp32")) {
     Serial.println("MDNS responder started");


### PR DESCRIPTION
## 変更内容

既存のCONNECTION_TIMEOUT定数を活用し、WiFi接続処理にタイムアウト機能を実装しました。

### 主な変更点
1. タイムアウト処理の実装
   - 30秒のタイムアウト時間を設定
   - 接続試行時間の監視と制御

2. ユーザーフィードバックの改善
   - 接続試行中の進捗表示
   - タイムアウト時の明確なエラーメッセージ
   - 接続失敗時のトラブルシューティング情報

3. 省電力対策
   - タイムアウト時のWiFi切断
   - WiFiモードのオフ化

4. サンプルコードの更新
   - example/HelloServer/にも同様の改善を適用
   - Serial出力メッセージの調整

### テスト手順
1. 正常系
   - 正しいWiFi認証情報での接続確認
   - 30秒以内の接続成功

2. 異常系
   - 誤ったWiFi認証情報でのタイムアウト確認
   - タイムアウト後のエラーメッセージ表示
   - WiFi切断の動作確認

### 動作確認環境
- M5Stack Core2
- Arduino IDE 2.2.1
- M5Unified v0.1.12
- M5Stack-LLM v0.0.1

Fixes #1