### PR TITLE
LLMモジュール処理のタイムアウト機能を追加

### DIFF
--- a/M5LLMServer.ino
+++ b/M5LLMServer.ino
@@ -20,7 +20,6 @@ bool processing = false;
 bool timeout_occurred = false;
 TaskHandle_t timeout_task_handle = NULL;
 
-// タイムアウト監視タスク
 void timeoutCheckTask(void* parameter) {
   unsigned long start_time = millis();
 
@@ -88,7 +87,6 @@ void handleAsk() {
   });
   M5.Display.println();
 
-  // 処理完了
   processing = false;
 
   // タイムアウトタスクが実行中の場合は削除
@@ -120,7 +118,7 @@ void setup() {
   M5.Display.setTextSize(2);
   M5.Display.setTextScroll(true);
 
-  // Initialize Module LLM
+  // LLMモジュールの初期化
   // Serial2.begin(115200, SERIAL_8N1, 16, 17);  // Basic
   Serial2.begin(115200, SERIAL_8N1, 13, 14);  // Core2
   // Serial2.begin(115200, SERIAL_8N1, 18, 17);  // CoreS3
@@ -141,7 +139,7 @@ void setup() {
   llm_config.max_token_len = 1023;
   llm_work_id = module_llm.llm.setup(llm_config);
 
-  // Setup WiFi
+  // WiFiの設定
   M5.Display.printf(">> Connecting to WiFi..\n");
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);
@@ -175,7 +173,7 @@ void setup() {
     M5.Display.println("MDNS responder started");
   }
 
-  // Setup server routes
+  // サーバールートの設定
   server.on("/", handleRoot);
   server.on("/ask", handleAsk);
   server.onNotFound(handleNotFound);

--- a/M5LLMServer.ino
+++ b/M5LLMServer.ino
@@ -173,7 +173,7 @@ void setup() {
     M5.Display.println("MDNS responder started");
   }
 
-  // サーバールートの設定
+  // ルーティング設定
   server.on("/", handleRoot);
   server.on("/ask", handleAsk);
   server.onNotFound(handleNotFound);

--- a/M5LLMServer.ino
+++ b/M5LLMServer.ino
@@ -18,7 +18,6 @@ String llm_work_id;
 String current_result;
 bool processing = false;
 bool timeout_occurred = false;
-const unsigned long CONNECTION_TIMEOUT = 30000;
 TaskHandle_t timeout_task_handle = NULL;
 
 // タイムアウト監視タスク

--- a/config.h
+++ b/config.h
@@ -4,6 +4,7 @@
 extern const char* ssid;
 extern const char* password;
 
+#define CONNECTION_TIMEOUT 30000
 #define LLM_PROCESSING_TIMEOUT 60000
 
 #endif

--- a/config.h
+++ b/config.h
@@ -4,7 +4,6 @@
 extern const char* ssid;
 extern const char* password;
 
-// LLM処理のタイムアウト時間（ミリ秒）
 #define LLM_PROCESSING_TIMEOUT 60000
 
 #endif

--- a/config.h
+++ b/config.h
@@ -4,4 +4,7 @@
 extern const char* ssid;
 extern const char* password;
 
+// LLM処理のタイムアウト時間（ミリ秒）
+#define LLM_PROCESSING_TIMEOUT 60000
+
 #endif


### PR DESCRIPTION
## 変更内容

LLMモジュールでの推論処理にタイムアウト機能を実装しました。

### 実装詳細

1. タイムアウト時間の設定
   - config.hにLLM_PROCESSING_TIMEOUT定数（デフォルト60秒）を追加
   - 設定値を変更可能な設計

2. タイムアウト処理の実装
   - ESP32のFreeRTOSタスク機能を利用
   - タイムアウト監視用の独立したタスクを作成
   - 1秒間隔でタイムアウトチェックを実行

3. エラーハンドリング
   - タイムアウト発生時は処理を中断
   - ユーザーにわかりやすいエラーメッセージを表示
   - 処理中フラグとリソースを適切に解放

### テスト方法

1. 通常の短い質問での動作確認
   - タイムアウトが発生しないことを確認
   - 正常に結果が返ることを確認

2. 長時間の処理が必要な質問でのテスト
   - 60秒後にタイムアウトすることを確認
   - エラーメッセージが正しく表示されることを確認
   - サーバーが再び利用可能な状態に戻ることを確認
   
### テスト用の長時間処理が必要な質問サンプル

a. 長文生成系：
```
Write a comprehensive 5000+ word essay on the history, features, and core design principles of the Python programming language. Include code examples for each topic and compare it with other major programming languages. Discuss its evolution, ecosystem, and impact on modern software development.
```

b. 複雑な分析系：
```
Analyze and compare machine learning, deep learning, and reinforcement learning in detail. Explain the theoretical background, mathematical foundations, implementation methods, practical applications, and limitations of each approach. Provide specific business use cases and discuss future trends in AI development.
```

c. 大量データ処理系：
```
Analyze economic indicators (GDP, inflation rate, unemployment rate, trade balance, etc.) from the past 20 years for 50 major countries. Classify their economic growth patterns, identify key factors influencing each pattern, and provide economic forecasts for the next decade with detailed justifications.
```

### 関連Issue
Closes #4